### PR TITLE
FO-1385: Kunne benytte ip for a na backend

### DIFF
--- a/src/frontend/src/felles/konstanter.js
+++ b/src/frontend/src/felles/konstanter.js
@@ -1,6 +1,6 @@
 import { erDev } from './utils/dev';
 
-export const RESTURL = erDev() ? 'http://localhost:8800/mia/rest' : '/mia/rest';
+export const RESTURL = erDev() ? `http://${window.location.hostname}:8800/mia/rest` : '/mia/rest';
 export const STATUS = {
   feilet: 'FEILET',
   lastet: 'LASTET',

--- a/src/frontend/src/felles/utils/dev.js
+++ b/src/frontend/src/felles/utils/dev.js
@@ -1,5 +1,6 @@
 export const erDev = () => erDevUrl(window.location.href);
 
 export function erDevUrl(url) {
-  return url.includes('debug=true') || url.includes('devillo.no:8486') || url.includes('localhost:');
+  let lokalIpRegex = /^http:\/\/((10\.[0-255])|(172\.)|(192\.168\.))/;
+  return url.includes('debug=true') || url.includes('devillo.no:8486') || url.includes('localhost:') || lokalIpRegex.test(url);
 }


### PR DESCRIPTION
Nå backend vha ip adresse dersom man oppgir det isteden for localhost, for å kunne teste på mobile enheter som ikke gjenkjenner localhost.